### PR TITLE
Add `data_length` field to the general header

### DIFF
--- a/codegen/src/persist_index/generator.rs
+++ b/codegen/src/persist_index/generator.rs
@@ -101,8 +101,8 @@ impl Generator {
             .map(|f| f.ident.as_ref().unwrap())
             .map(|i| {
                 quote! {
-                    for page in &self.#i {
-                        persist_page(&page, file)?;
+                    for mut page in &mut self.#i {
+                        persist_page(&mut page, file)?;
                     }
                 }
             })
@@ -126,7 +126,7 @@ impl Generator {
                     header.unwrap()
                 }
 
-                pub fn persist(&self, file: &mut std::fs::File) -> eyre::Result<()> {
+                pub fn persist(&mut self, file: &mut std::fs::File) -> eyre::Result<()> {
                     #(#persist_logic)*
 
                     Ok(())

--- a/codegen/src/persist_table/generator/space_serialize.rs
+++ b/codegen/src/persist_table/generator/space_serialize.rs
@@ -70,6 +70,7 @@ impl Generator {
                     next_id: 0.into(),
                     page_type: PageType::SpaceInfo,
                     space_id: 0.into(),
+                    data_length: 0,
                 };
                 GeneralPage {
                     header,
@@ -116,6 +117,7 @@ impl Generator {
                     primary_index.first().unwrap().header.page_id.into(),
                     primary_index.last().unwrap().header.page_id.into()
                 );
+                info.inner.page_count += primary_index.len() as u32;
 
                 info.inner.primary_key_intervals = vec![interval];
                 let previous_header = &mut primary_index.last_mut().unwrap().header;

--- a/codegen/src/persist_table/generator/space_serialize.rs
+++ b/codegen/src/persist_table/generator/space_serialize.rs
@@ -153,21 +153,21 @@ impl Generator {
 
         Ok(quote! {
             impl<const DATA_LENGTH: usize> #space_ident<DATA_LENGTH> {
-                pub fn persist(&self) -> eyre::Result<()> {
+                pub fn persist(&mut self) -> eyre::Result<()> {
                     let file_name = #file_name;
                     let path = std::path::Path::new(format!("{}/{}", &self.path , file_name).as_str());
                     let prefix = &self.path;
                     std::fs::create_dir_all(prefix).unwrap();
 
                     let mut file = std::fs::File::create(format!("{}/{}", &self.path , file_name))?;
-                    persist_page(&self.info, &mut file)?;
+                    persist_page(&mut self.info, &mut file)?;
 
-                    for primary_index_page in &self.primary_index {
-                        persist_page(&primary_index_page, &mut file)?;
+                    for mut primary_index_page in &mut self.primary_index {
+                        persist_page(&mut primary_index_page, &mut file)?;
                     }
                     self.indexes.persist(&mut file)?;
-                    for data_page in &self.primary_index {
-                        persist_page(&data_page, &mut file)?;
+                    for mut data_page in &mut self.primary_index {
+                        persist_page(&mut data_page, &mut file)?;
                     }
 
                     Ok(())

--- a/src/page/header.rs
+++ b/src/page/header.rs
@@ -2,12 +2,10 @@
 
 use rkyv::{Archive, Deserialize, Serialize};
 
-use crate::page;
+use crate::{page, PAGE_SIZE};
 use crate::page::ty::PageType;
 use crate::space;
 use crate::util::Persistable;
-
-use super::PAGE_SIZE;
 
 pub const GENERAL_HEADER_SIZE: usize = 24;
 
@@ -77,8 +75,7 @@ impl Persistable for GeneralHeader {
 mod test {
     use crate::page::header::GENERAL_HEADER_SIZE;
     use crate::util::Persistable;
-    use crate::{GeneralHeader, PageType};
-    use super::super::PAGE_SIZE;
+    use crate::{GeneralHeader, PageType, PAGE_SIZE};
 
     #[test]
     fn test_as_bytes() {

--- a/src/page/header.rs
+++ b/src/page/header.rs
@@ -7,7 +7,9 @@ use crate::page::ty::PageType;
 use crate::space;
 use crate::util::Persistable;
 
-pub const GENERAL_HEADER_SIZE: usize = 20;
+use super::PAGE_SIZE;
+
+pub const GENERAL_HEADER_SIZE: usize = 24;
 
 /// Header that appears on every page before it's inner data.
 #[derive(
@@ -19,6 +21,7 @@ pub struct GeneralHeader {
     pub previous_id: page::PageId,
     pub next_id: page::PageId,
     pub page_type: PageType,
+    pub data_length: u32,
 }
 
 impl GeneralHeader {
@@ -29,6 +32,7 @@ impl GeneralHeader {
             next_id: 0.into(),
             page_type: type_,
             space_id,
+            data_length: PAGE_SIZE as u32,
         }
     }
 
@@ -43,6 +47,7 @@ impl GeneralHeader {
             next_id: 0.into(),
             page_type: self.page_type,
             space_id: self.space_id,
+            data_length: PAGE_SIZE as u32,
         }
     }
 
@@ -57,6 +62,7 @@ impl GeneralHeader {
             next_id: 0.into(),
             page_type,
             space_id: self.space_id,
+            data_length: PAGE_SIZE as u32,
         }
     }
 }
@@ -72,6 +78,7 @@ mod test {
     use crate::page::header::GENERAL_HEADER_SIZE;
     use crate::util::Persistable;
     use crate::{GeneralHeader, PageType};
+    use super::super::PAGE_SIZE;
 
     #[test]
     fn test_as_bytes() {
@@ -81,6 +88,7 @@ mod test {
             next_id: 3.into(),
             page_type: PageType::Empty,
             space_id: 4.into(),
+            data_length: PAGE_SIZE as u32,
         };
         let bytes = header.as_bytes();
         assert_eq!(bytes.as_ref().len(), GENERAL_HEADER_SIZE)
@@ -94,6 +102,7 @@ mod test {
             next_id: (u32::MAX - 2).into(),
             page_type: PageType::Empty,
             space_id: (u32::MAX - 3).into(),
+            data_length: PAGE_SIZE as u32,
         };
         let bytes = header.as_bytes();
         assert_eq!(bytes.as_ref().len(), GENERAL_HEADER_SIZE)

--- a/src/page/index.rs
+++ b/src/page/index.rs
@@ -213,6 +213,6 @@ mod test {
         let page = pages.get(0).unwrap();
 
         let bytes = page.as_bytes();
-        assert!(bytes.as_ref().len() < INNER_PAGE_LENGTH)
+        assert!(bytes.as_ref().len() <= INNER_PAGE_LENGTH)
     }
 }

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -83,8 +83,7 @@ pub struct General<Inner> {
 mod tests {
     use crate::page::ty::PageType;
     use crate::page::{GeneralHeader, HEADER_LENGTH};
-
-    use super::PAGE_SIZE;
+    use crate::PAGE_SIZE;
 
     fn get_general_header() -> GeneralHeader {
         GeneralHeader {

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -31,9 +31,10 @@ pub const PAGE_SIZE: usize = 4096 * 4;
 /// * `next_id` - 4 bytes,
 /// * `page_type` - 2 bytes,
 /// * `space_id` - 4 bytes,
+/// * `data_length` - 4 bytes,
 ///
 /// **2 bytes are added by rkyv implicitly.**
-pub const HEADER_LENGTH: usize = 20;
+pub const HEADER_LENGTH: usize = 24;
 
 /// Length of the inner part of [`General`] page. It's counted as [`PAGE_SIZE`]
 /// without [`General`] page [`HEADER_LENGTH`].
@@ -83,6 +84,8 @@ mod tests {
     use crate::page::ty::PageType;
     use crate::page::{GeneralHeader, HEADER_LENGTH};
 
+    use super::PAGE_SIZE;
+
     fn get_general_header() -> GeneralHeader {
         GeneralHeader {
             page_id: 1.into(),
@@ -90,6 +93,7 @@ mod tests {
             next_id: 4.into(),
             page_type: PageType::Index,
             space_id: 5.into(),
+            data_length: PAGE_SIZE as u32,
         }
     }
 

--- a/src/page/space_info.rs
+++ b/src/page/space_info.rs
@@ -6,9 +6,7 @@ use rkyv::{Archive, Deserialize, Serialize};
 use crate::page::ty::PageType;
 use crate::page::{GeneralHeader, INNER_PAGE_LENGTH};
 use crate::util::Persistable;
-use crate::{page, space};
-
-use super::PAGE_SIZE;
+use crate::{page, space, PAGE_SIZE};
 
 pub type SpaceName = String;
 

--- a/src/page/space_info.rs
+++ b/src/page/space_info.rs
@@ -8,6 +8,8 @@ use crate::page::{GeneralHeader, INNER_PAGE_LENGTH};
 use crate::util::Persistable;
 use crate::{page, space};
 
+use super::PAGE_SIZE;
+
 pub type SpaceName = String;
 
 // TODO: This must be modified to describe table structure. I think page intervals
@@ -43,6 +45,7 @@ impl From<SpaceInfo> for page::General<SpaceInfo> {
             next_id: page::PageId::from(0),
             page_type: PageType::SpaceInfo,
             space_id: info.id,
+            data_length: PAGE_SIZE as u32,
         };
         page::General {
             header,

--- a/src/page/util.rs
+++ b/src/page/util.rs
@@ -43,16 +43,19 @@ pub fn map_data_pages_to_general<const DATA_LENGTH: usize>(
     general_pages
 }
 
-pub fn persist_page<T>(page: &GeneralPage<T>, file: &mut std::fs::File) -> eyre::Result<()>
+pub fn persist_page<T>(page: &mut GeneralPage<T>, file: &mut std::fs::File) -> eyre::Result<()>
 where
     T: Persistable,
 {
     use std::io::prelude::*;
 
     let page_count = page.header.page_id.0 as i64 + 1;
+    let inner_bytes = page.inner.as_bytes();
+    page.header.data_length = inner_bytes.as_ref().len() as u32;
+    println!("{:?}",  inner_bytes.as_ref().len());
 
     file.write_all(page.header.as_bytes().as_ref())?;
-    file.write_all(page.inner.as_bytes().as_ref())?;
+    file.write_all(inner_bytes.as_ref())?;
     let curr_position = file.stream_position()?;
     file.seek(std::io::SeekFrom::Current(
         (page_count * PAGE_SIZE as i64) - curr_position as i64,

--- a/src/page/util.rs
+++ b/src/page/util.rs
@@ -66,7 +66,7 @@ mod test {
     use scc::TreeIndex;
 
     use crate::page::INNER_PAGE_LENGTH;
-    use crate::{map_index_pages_to_general, map_unique_tree_index, GeneralHeader, Link, PageType};
+    use crate::{map_index_pages_to_general, map_unique_tree_index, GeneralHeader, Link, PageType, PAGE_SIZE};
 
     #[test]
     fn test_map() {
@@ -87,6 +87,7 @@ mod test {
             previous_id: 0.into(),
             next_id: 0.into(),
             page_type: PageType::SpaceInfo,
+            data_length: PAGE_SIZE as u32,
         };
         let generalised = map_index_pages_to_general(res, &mut header);
         assert_eq!(generalised.len(), 3);


### PR DESCRIPTION
This PR adds a new field `data_length` to the `GeneralHeader` data structure.