### PR TITLE
Add a `data_version` field to the header

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub use page::{
     map_data_pages_to_general, map_index_pages_to_general, map_tree_index, map_unique_tree_index,
     parse_data_page, parse_page, persist_page, Data as DataPage, General as GeneralPage,
     GeneralHeader, IndexPage as IndexData, Interval, PageType, SpaceInfo as SpaceInfoData,
-    GENERAL_HEADER_SIZE, INNER_PAGE_SIZE, PAGE_SIZE,
+    GENERAL_HEADER_SIZE, INNER_PAGE_SIZE, PAGE_SIZE, DATA_VERSION,
 };
 pub use persistence::{PersistableIndex, PersistableTable};
 pub use util::{align, Persistable, SizeMeasurable};

--- a/src/page/header.rs
+++ b/src/page/header.rs
@@ -7,11 +7,14 @@ use crate::space;
 use crate::util::Persistable;
 use crate::{page, GENERAL_HEADER_SIZE, PAGE_SIZE};
 
+pub const DATA_VERSION: u32 = 1u32;
+
 /// Header that appears on every page before it's inner data.
 #[derive(
     Archive, Copy, Clone, Deserialize, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize,
 )]
 pub struct GeneralHeader {
+    pub data_version: u32,
     pub space_id: space::Id,
     pub page_id: page::PageId,
     pub previous_id: page::PageId,
@@ -23,6 +26,7 @@ pub struct GeneralHeader {
 impl GeneralHeader {
     pub fn new(page_id: page::PageId, type_: PageType, space_id: space::Id) -> Self {
         Self {
+            data_version: DATA_VERSION,
             page_id,
             previous_id: 0.into(),
             next_id: 0.into(),
@@ -38,6 +42,7 @@ impl GeneralHeader {
     pub fn follow(&mut self) -> Self {
         self.next_id = self.page_id.next();
         Self {
+            data_version: DATA_VERSION,
             page_id: self.next_id,
             previous_id: self.page_id,
             next_id: 0.into(),
@@ -53,6 +58,7 @@ impl GeneralHeader {
     pub fn follow_with(&mut self, page_type: PageType) -> Self {
         self.next_id = self.page_id.next();
         Self {
+            data_version: DATA_VERSION,
             page_id: self.next_id,
             previous_id: self.page_id,
             next_id: 0.into(),
@@ -71,12 +77,14 @@ impl Persistable for GeneralHeader {
 
 #[cfg(test)]
 mod test {
+    use crate::page::header::DATA_VERSION;
     use crate::util::Persistable;
     use crate::{GeneralHeader, PageType, GENERAL_HEADER_SIZE, PAGE_SIZE};
 
     #[test]
     fn test_as_bytes() {
         let header = GeneralHeader {
+            data_version: DATA_VERSION,
             page_id: 1.into(),
             previous_id: 2.into(),
             next_id: 3.into(),
@@ -91,6 +99,7 @@ mod test {
     #[test]
     fn test_as_bytes_max() {
         let header = GeneralHeader {
+            data_version: DATA_VERSION,
             page_id: u32::MAX.into(),
             previous_id: (u32::MAX - 1).into(),
             next_id: (u32::MAX - 2).into(),

--- a/src/page/mod.rs
+++ b/src/page/mod.rs
@@ -9,7 +9,7 @@ use derive_more::{Display, From};
 use rkyv::{Archive, Deserialize, Serialize};
 
 pub use data::Data;
-pub use header::GeneralHeader;
+pub use header::{GeneralHeader, DATA_VERSION};
 pub use index::{map_tree_index, map_unique_tree_index, IndexPage};
 pub use space_info::{Interval, SpaceInfo};
 pub use ty::PageType;
@@ -37,7 +37,7 @@ pub const PAGE_SIZE: usize = 4096 * 4;
 /// * `data_length` - 4 bytes,
 ///
 /// **2 bytes are added by rkyv implicitly.**
-pub const GENERAL_HEADER_SIZE: usize = 24;
+pub const GENERAL_HEADER_SIZE: usize = 28;
 
 /// Length of the inner part of [`General`] page. It's counted as [`PAGE_SIZE`]
 /// without [`General`] page [`GENERAL_HEADER_SIZE`].
@@ -85,11 +85,12 @@ pub struct General<Inner> {
 #[cfg(test)]
 mod tests {
     use crate::page::ty::PageType;
-    use crate::page::{GeneralHeader, GENERAL_HEADER_SIZE};
+    use crate::page::{GeneralHeader, GENERAL_HEADER_SIZE, DATA_VERSION};
     use crate::PAGE_SIZE;
 
     fn get_general_header() -> GeneralHeader {
         GeneralHeader {
+            data_version: DATA_VERSION,
             page_id: 1.into(),
             previous_id: 2.into(),
             next_id: 4.into(),

--- a/src/page/util.rs
+++ b/src/page/util.rs
@@ -136,7 +136,7 @@ mod test {
 
     use crate::page::INNER_PAGE_SIZE;
     use crate::{
-        map_index_pages_to_general, map_unique_tree_index, GeneralHeader, Link, PageType, PAGE_SIZE,
+        map_index_pages_to_general, map_unique_tree_index, GeneralHeader, Link, PageType, DATA_VERSION, PAGE_SIZE
     };
 
     #[test]
@@ -153,6 +153,7 @@ mod test {
 
         let res = map_unique_tree_index::<_, { INNER_PAGE_SIZE }>(&index);
         let mut header = GeneralHeader {
+            data_version: DATA_VERSION,
             space_id: 0.into(),
             page_id: 0.into(),
             previous_id: 0.into(),


### PR DESCRIPTION
This PR adds a new `data_version` field to the header.

A few questions:

1. What is the best data type for the data version? Currently it is just a `u32`, but maybe it is better to keep a semver-like triple of numbers?
2. Where to put the logic for updating the data version?