### PR TITLE
Seek before writing in the `persist_page` function

### DIFF
--- a/src/page/util.rs
+++ b/src/page/util.rs
@@ -57,7 +57,7 @@ where
 {
     use std::io::prelude::*;
 
-    file.seek(io::SeekFrom::Start(page.header.page_id.0 as u64 * PAGE_SIZE as u64))?;
+    seek_to_page_start(file, page.header.page_id.0)?;
 
     let page_count = page.header.page_id.0 as i64 + 1;
     let inner_bytes = page.inner.as_bytes();

--- a/src/page/util.rs
+++ b/src/page/util.rs
@@ -57,6 +57,8 @@ where
 {
     use std::io::prelude::*;
 
+    file.seek(io::SeekFrom::Start(page.header.page_id.0 as u64 * PAGE_SIZE as u64))?;
+
     let page_count = page.header.page_id.0 as i64 + 1;
     let inner_bytes = page.inner.as_bytes();
     page.header.data_length = inner_bytes.as_ref().len() as u32;
@@ -370,7 +372,9 @@ mod test {
         // read the data
         let mut file = std::fs::File::open(filename).unwrap();
         let index_pages =
-            read_index_pages::<String, PAGE_SIZE>(&mut file, "string_index", vec![Interval(1, 2)])
+            read_index_pages::<String, PAGE_SIZE>(&mut file, "string_index", vec![
+                Interval(1, 2), Interval(5, 6)
+                ])
                 .unwrap();
         assert_eq!(index_pages[0].index_values.len(), 1);
         assert_eq!(index_pages[0].index_values[0].key, "first_value");


### PR DESCRIPTION
If pages are written not sequentially, but with page ids come for example in sequence 1, 2, 5, 6, then they are written incorrectly to wrong places in the file. This PR fixes it by adding a seek before writing.