### PR TITLE
Impl SizeMeasurable for Arc and lock free Set

### DIFF
--- a/src/util/sized.rs
+++ b/src/util/sized.rs
@@ -1,5 +1,5 @@
 use crate::link::{Link, LINK_LENGTH};
-use std::mem;
+use std::{mem, sync::Arc};
 use uuid::Uuid;
 
 pub const fn align(len: usize) -> usize {
@@ -63,6 +63,20 @@ impl SizeMeasurable for String {
         } else {
             align(self.len() + 8)
         }
+    }
+}
+
+impl<T: SizeMeasurable> SizeMeasurable for Arc<T> {
+    fn aligned_size(&self) -> usize {
+        self.as_ref().aligned_size()
+    }
+}
+impl<T: SizeMeasurable> SizeMeasurable for lockfree::set::Set<T> {
+    fn aligned_size(&self) -> usize {
+        self
+        .iter()
+        .map(|elem| elem.aligned_size())
+        .sum()
     }
 }
 


### PR DESCRIPTION
Add new impls for SizeMeasurable trait. @Handy-caT commented [here](https://github.com/a-tsibin/WorkTable/commit/e4d8c439c9db80a4876942b9bf46eb8de282754d#diff-6d80b1346df0aa5eeabd0a57c84809139cd3afe84f489a5757f78cf543582b97R40) that this impls should stay in WT repo, but if we moves SizeMeasurable to DB, we can have impls in WT or needs to create something like trait SizeMeasurableExt.